### PR TITLE
Fix indentation bug in intrusion detection service

### DIFF
--- a/flask_backend/services/intrusion_detection.py
+++ b/flask_backend/services/intrusion_detection.py
@@ -496,7 +496,8 @@ class IntrusionDetectionSystem:
             })
         
         return packet_data
-      async def analyze_packet(self, packet_data: Dict[str, Any]) -> List[DetectionAlert]:
+
+    async def analyze_packet(self, packet_data: Dict[str, Any]) -> List[DetectionAlert]:
         """Analyze packet using all detection engines"""
         self.packets_processed += 1
         alerts = []
@@ -814,9 +815,10 @@ class IntrusionDetectionSystem:
         except Exception as e:
             self.logger.error(f"Failed to get detection rules: {e}")
             return []
-      def add_detection_rule(self, name: str, pattern: str, action: str, 
-                          severity: str = 'MEDIUM', description: str = '', 
-                          enabled: bool = True, **kwargs) -> str:
+
+    def add_detection_rule(self, name: str, pattern: str, action: str,
+                           severity: str = 'MEDIUM', description: str = '',
+                           enabled: bool = True, **kwargs) -> str:
         """Add a new detection rule"""
         try:
             rule_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary
- correct indentation for `analyze_packet` and `add_detection_rule` methods in `intrusion_detection.py`
- run `py_compile` to verify Python sources

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875037defd08330bc96893a7488861a